### PR TITLE
Default value of ES_SCHEME should not have quotes

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ES_HOST=${ES_HOST:-\"+window.location.hostname+\"}
 ES_PORT=${ES_PORT:-9200}
-ES_SCHEME=${ES_SCHEME:-\"http\"}
+ES_SCHEME=${ES_SCHEME:-http}
 
 cat << EOF > /usr/share/nginx/html/config.js
 define(['settings'],


### PR DESCRIPTION
Currently, if this image is run without passing any ES_SCHEME, the value of 'elasticsearch' in the JSON ends up being: `""http://""+window.location.hostname+":9200"`.

The default value of ES_SCHEME becomes `"http"`, which is wrong; it should not include the quotes; should be just `http`.

This pull request removes the quotes and fixes the problem.
