### PR TITLE
Disable IPv6 support for Nginx

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -3,6 +3,11 @@ ES_HOST=${ES_HOST:-\"+window.location.hostname+\"}
 ES_PORT=${ES_PORT:-9200}
 ES_SCHEME=${ES_SCHEME:-http}
 
+# disable ipv6 support
+if [ ! -f /proc/net/if_inet6 ]; then
+  sed -e '/listen \[::\]:80/ s/^#*/#/' -i /etc/nginx/sites-enabled/*
+fi
+
 cat << EOF > /usr/share/nginx/html/config.js
 define(['settings'],
 function (Settings) {


### PR DESCRIPTION
On some servers, IPv6 is not available, so Nginx can't listen on  [::]:80 

```
2014/12/19 07:18:32 [emerg] 484#0: socket() [::]:80 failed (97: Address family not supported by protocol)
```

I removed the line and the container start successfully.
